### PR TITLE
fix(core): init trigger if not exist

### DIFF
--- a/core/src/components/cat-menu/cat-menu.tsx
+++ b/core/src/components/cat-menu/cat-menu.tsx
@@ -64,18 +64,6 @@ export class CatMenu {
   }
 
   componentDidLoad(): void {
-    this.trigger = this.findTrigger();
-    this.trigger?.setAttribute('aria-haspopup', 'true');
-    this.trigger?.setAttribute('aria-expanded', 'false');
-    this.trigger?.setAttribute('aria-controls', this.contentId);
-    this.content?.setAttribute('id', this.contentId);
-    if (this.trigger && this.content) {
-      this.trigger?.addEventListener('click', () => {
-        this.trap?.active ? this.close() : this.show();
-      });
-      autoUpdate(this.trigger, this.content, () => this.update());
-    }
-
     this.initTrigger();
     this.keyListener = event => {
       if (this.content && ['ArrowDown', 'ArrowUp'].includes(event.key)) {
@@ -119,7 +107,9 @@ export class CatMenu {
     this.trigger?.setAttribute('aria-controls', this.contentId);
     this.content?.setAttribute('id', this.contentId);
     if (this.trigger && this.content) {
-      this.trigger?.addEventListener('click', () => this.show());
+      this.trigger?.addEventListener('click', () => {
+        this.trap?.active ? this.close() : this.show();
+      });
       autoUpdate(this.trigger, this.content, () => this.update());
     }
   }

--- a/core/src/components/cat-menu/cat-menu.tsx
+++ b/core/src/components/cat-menu/cat-menu.tsx
@@ -38,6 +38,11 @@ export class CatMenu {
 
   @Listen('catClick')
   clickHandler(event: CustomEvent<MouseEvent>) {
+    if (!this.trigger) {
+      this.initTrigger();
+      this.show();
+    }
+
     // hide menu on button click
     if (this.content && event.composedPath().includes(this.content)) {
       this.close();
@@ -54,16 +59,7 @@ export class CatMenu {
   }
 
   componentDidLoad(): void {
-    this.trigger = this.findTrigger();
-    this.trigger?.setAttribute('aria-haspopup', 'true');
-    this.trigger?.setAttribute('aria-expanded', 'false');
-    this.trigger?.setAttribute('aria-controls', this.contentId);
-    this.content?.setAttribute('id', this.contentId);
-    if (this.trigger && this.content) {
-      this.trigger?.addEventListener('click', () => this.show());
-      autoUpdate(this.trigger, this.content, () => this.update());
-    }
-
+    this.initTrigger();
     this.keyListener = event => {
       if (this.content && ['ArrowDown', 'ArrowUp'].includes(event.key)) {
         const targetElements = tabbable(this.content, { includeContainer: false, getShadowRoot: true });
@@ -97,6 +93,18 @@ export class CatMenu {
 
   private get contentId() {
     return `cat-menu-${this.id}`;
+  }
+
+  private initTrigger() {
+    this.trigger = this.findTrigger();
+    this.trigger?.setAttribute('aria-haspopup', 'true');
+    this.trigger?.setAttribute('aria-expanded', 'false');
+    this.trigger?.setAttribute('aria-controls', this.contentId);
+    this.content?.setAttribute('id', this.contentId);
+    if (this.trigger && this.content) {
+      this.trigger?.addEventListener('click', () => this.show());
+      autoUpdate(this.trigger, this.content, () => this.update());
+    }
   }
 
   private show() {

--- a/core/src/index.html
+++ b/core/src/index.html
@@ -489,9 +489,9 @@
               </ul>
             </nav>
           </cat-menu>
-          <h2>Menu in card</h2>
+
           <cat-card>
-            Hello world
+            Menu inside a card
             <cat-menu>
               <cat-button slot="trigger">Click me</cat-button>
               <nav slot="content">

--- a/core/src/index.html
+++ b/core/src/index.html
@@ -489,6 +489,19 @@
               </ul>
             </nav>
           </cat-menu>
+          <h2>Menu in card</h2>
+          <cat-card>
+            Hello world
+            <cat-menu>
+              <cat-button slot="trigger">Click me</cat-button>
+              <nav slot="content">
+                <ul>
+                  <li><cat-button>Item A</cat-button></li>
+                  <li><cat-button>Item B</cat-button></li>
+                </ul>
+              </nav>
+            </cat-menu>
+          </cat-card>
         </section>
 
         <!-- <section id="modal">


### PR DESCRIPTION
[PMI-564](https://coyoapp.atlassian.net/browse/PMI-564)

The bug is due to two things: 
- The first is the hierarchy in the stencil lifecycle: children are loaded before the parent component. `componentDidLoad`
- Second the `tabbable` method does not recognize the elements that are hidden. 

And what happens is that first the cat-menu load is called and then the load of the cat-card and in the load of the cat-menu the element is still hidden (`visibility: inherit`) since cat-card has not yet loaded, when cat-card finishes loading is when it is already visible and the cat-menu trigger is initialized in its load and as I commented, the `firstTabbable` does not detect any element since it has visibility hidden.

If you have any questions let me know.