### PR TITLE
fix(core): rework tooltip trigger selection

### DIFF
--- a/core/src/components/cat-tooltip/cat-tooltip.scss
+++ b/core/src/components/cat-tooltip/cat-tooltip.scss
@@ -73,13 +73,3 @@ $-shift-padding: 0.25rem; // padding given to the shift() middleware
     padding: 1rem 1.5rem;
   }
 }
-
-// ----- trigger
-
-.tooltip-trigger {
-  display: inline-block;
-
-  &:focus {
-    outline: none;
-  }
-}

--- a/core/src/components/cat-tooltip/cat-tooltip.spec.tsx
+++ b/core/src/components/cat-tooltip/cat-tooltip.spec.tsx
@@ -14,9 +14,7 @@ describe('cat-tooltip', () => {
     expect(page.root).toEqualHtml(`
       <cat-tooltip content="This is a tooltip">
         <mock:shadow-root>
-          <div aria-describedby="cat-tooltip-0" class="tooltip-trigger" tabindex="0">
-            <slot></slot>
-          </div>
+          <slot></slot>
           <div class="tooltip tooltip-m" id="cat-tooltip-0">This is a tooltip</div>
         </mock:shadow-root>
         <p>Hover me</p>

--- a/core/src/index.html
+++ b/core/src/index.html
@@ -874,30 +874,35 @@
           </cat-tooltip>
           <h3>Size</h3>
           <cat-tooltip size="s" content="This is a small tooltip">
-            <p>Hover Me (S)</p>
+            <p class="cat-inline-flex">Hover Me (S)</p>
           </cat-tooltip>
+          <br />
           <cat-tooltip size="s" round="true" content="This is a small tooltip">
-            <p>Hover Me (S round)</p>
+            <p class="cat-inline-flex">Hover Me (S round)</p>
           </cat-tooltip>
+          <br />
           <cat-tooltip size="m" content="This is a regular tooltip">
-            <p>Hover Me (M)</p>
+            <p class="cat-inline-flex">Hover Me (M)</p>
           </cat-tooltip>
+          <br />
           <cat-tooltip size="m" round="true" content="This is a regular tooltip">
-            <p>Hover Me (M round)</p>
+            <p class="cat-inline-flex">Hover Me (M round)</p>
           </cat-tooltip>
+          <br />
           <cat-tooltip size="l" content="This is a large tooltip">
-            <p>Hover Me (L)</p>
+            <p class="cat-inline-flex">Hover Me (L)</p>
           </cat-tooltip>
+          <br />
           <cat-tooltip size="l" round="true" content="This is a large tooltip">
-            <p>Hover Me (L round)</p>
+            <p class="cat-inline-flex">Hover Me (L round)</p>
           </cat-tooltip>
           <h3>Round</h3>
           <cat-tooltip round="true" content="This is a round tooltip">
-            <p>Hover Me (round)</p>
+            <p class="cat-inline-flex">Hover Me (round)</p>
           </cat-tooltip>
           <h3>Async</h3>
           <cat-tooltip id="async-tooltip" placement="bottom-end">
-            <p>Hover Me (async)</p>
+            <p class="cat-inline-flex">Hover Me (async)</p>
           </cat-tooltip>
           <script>
             const tooltipElem = document.getElementById('async-tooltip');


### PR DESCRIPTION
There are problems with the Tooltip trigger being automatically selected. This was raised by @ccanow. Goal is to make the first slot child always the tooltip trigger and not the first tabbable one