### PR TITLE
feat(core): inputs now use ellipsis when text is truncated

### DIFF
--- a/core/src/components/cat-input/cat-input.scss
+++ b/core/src/components/cat-input/cat-input.scss
@@ -113,6 +113,8 @@ input {
   outline: none;
   background: none;
 
+  @include cat-ellipsis(1);
+
   .input-disabled & {
     cursor: not-allowed;
     color: cat-token('color.ui.font.muted');

--- a/core/src/components/cat-input/cat-input.scss
+++ b/core/src/components/cat-input/cat-input.scss
@@ -112,8 +112,7 @@ input {
   border: none;
   outline: none;
   background: none;
-
-  @include cat-ellipsis(1);
+  @include cat-ellipsis;
 
   .input-disabled & {
     cursor: not-allowed;


### PR DESCRIPTION
Added our utility cat-ellipsis to the native input element inside the component.
This does not affect the text area component.