### PR TITLE
chore(core): fixed broken spacings in nav cat-card

### DIFF
--- a/core/src/components/cat-card/cat-card.scss
+++ b/core/src/components/cat-card/cat-card.scss
@@ -19,11 +19,6 @@ $-padding: 1.25rem;
   margin-bottom: 0 !important;
 }
 
-::slotted(nav),
-::slotted(nav:last-child) {
-  margin: #{$cat-body-margin-bottom * 0.5 - $-padding} #{-$-padding} !important;
-}
-
 // --- pull out helper classes
 
 ::slotted(.cat-card-pull) {

--- a/core/src/components/cat-card/cat-card.scss
+++ b/core/src/components/cat-card/cat-card.scss
@@ -19,6 +19,11 @@ $-padding: 1.25rem;
   margin-bottom: 0 !important;
 }
 
+::slotted(nav),
+::slotted(nav:last-child) {
+  margin: #{0.25rem - $-padding} #{0.25rem - $-padding} !important;
+}
+
 // --- pull out helper classes
 
 ::slotted(.cat-card-pull) {

--- a/core/src/index.html
+++ b/core/src/index.html
@@ -444,7 +444,7 @@
               </div>
               <h3>Navigation</h3>
               <div class="canvas-fake">
-                <cat-card class="cat-p-xs">
+                <cat-card>
                   <nav>
                     <ul>
                       <li class="cat-nav-head">Headline</li>

--- a/core/src/index.html
+++ b/core/src/index.html
@@ -444,7 +444,7 @@
               </div>
               <h3>Navigation</h3>
               <div class="canvas-fake">
-                <cat-card>
+                <cat-card class="cat-p-xs">
                   <nav>
                     <ul>
                       <li class="cat-nav-head">Headline</li>


### PR DESCRIPTION
I basically just removed the conditional styling for nav elements inside cat-cards as we do not need that anymore.
This would also mean that a card that's supposed to contain a nav element also needs the class "cat-p-xs" to work properly. Is that an acceptable solution or too manual?