### PR TITLE
fix: add flip fallback axis for tooltips

### DIFF
--- a/core/src/components/cat-tooltip/cat-tooltip.tsx
+++ b/core/src/components/cat-tooltip/cat-tooltip.tsx
@@ -152,7 +152,11 @@ export class CatTooltip {
       await computePosition(this.trigger, this.tooltip, {
         strategy: 'fixed',
         placement: this.placement,
-        middleware: [offset(CatTooltip.OFFSET), flip(), shift({ padding: CatTooltip.SHIFT_PADDING })]
+        middleware: [
+          offset(CatTooltip.OFFSET),
+          flip({ fallbackAxisSideDirection: 'start' }),
+          shift({ padding: CatTooltip.SHIFT_PADDING })
+        ]
       }).then(({ x, y }) => {
         if (this.tooltip) {
           Object.assign(this.tooltip.style, {


### PR DESCRIPTION
**Description:**
- as in current state tooltips have just a main axis fallback (eg: default placement is top, without enough space on the top side to display the tooltip it will fallback to the bottom side), in case of not enough space on the main axis, by adding `fallbackAxisSideDirection: 'start'`, as part of the options argument of `flip` method, will allow cross axis switch (eg: if not enough space on right side, flips to left side, if not enough space on left side it will flip cross axis to the top side)

**Screenshots:**
| Situation | Before | After |
| ------ | ------ | ------ |
| placement: right - enough space on all sides | ![image](https://github.com/haiilo/catalyst/assets/22702708/12335833-3cec-40b4-815a-6ca46ab3ecf5) | ![image](https://github.com/haiilo/catalyst/assets/22702708/c2896b3b-ebcb-4462-b8bb-fd1324267a44) |
| placement: right - not enough space on right side | ![image](https://github.com/haiilo/catalyst/assets/22702708/7de9479a-ca43-469c-a60f-2a9019b51d52) | ![image](https://github.com/haiilo/catalyst/assets/22702708/9a34c640-e937-491c-bade-279fe92472c6) |
| placement: right - not enough space on left or right side | ![image](https://github.com/haiilo/catalyst/assets/22702708/16e263be-789e-477b-a04b-0561d0474f75) | ![image](https://github.com/haiilo/catalyst/assets/22702708/625b113c-cb22-443e-9905-7c2e6c6ccea7) |

**References:**
- [COYOFOUR-22267 - [FE] Search: Tooltips not displayed on small viewports](https://haiilo.atlassian.net/browse/COYOFOUR-22267)
- [floating.ui - flip#fallbackaxissidedirection](https://floating-ui.com/docs/flip#fallbackaxissidedirection)