### PR TITLE
style(core): extend content width to 100% in cat-alert component

### DIFF
--- a/core/src/components/cat-alert/cat-alert.scss
+++ b/core/src/components/cat-alert/cat-alert.scss
@@ -20,6 +20,7 @@
 
 .content {
   align-self: center;
+  width: 100%;
 }
 
 ::slotted(:last-child) {


### PR DESCRIPTION
**What:**
extend width content of "cat-alert" component to 100%

**Why:**
I wanted to implement a design from design team which looks like this:
![image](https://github.com/haiilo/catalyst/assets/10977856/219151fc-f6ae-4933-80a9-fdfb9234a15c)

But for now "content" part is only consuming a part of allowed width in cat-alert component:
![image](https://github.com/haiilo/catalyst/assets/10977856/ffb3af22-fd5b-44d1-828f-01b2b0bcb9f9)
![image](https://github.com/haiilo/catalyst/assets/10977856/5bfeecab-786c-422c-84cc-3b3b182cca8f)

**What's proposed** 
set width: 100% to .content selector in the cat-alert component:
![image](https://github.com/haiilo/catalyst/assets/10977856/5bc7a56a-1e8a-442b-981f-38671199524d)

final result would look like this with **_no custom css in csi project_**
![image](https://github.com/haiilo/catalyst/assets/10977856/09b6e7d9-c806-4315-906f-ef9c2f690097)

