### PR TITLE
fix: datepicker disabled state change is unstable

### DIFF
--- a/angular/projects/catalyst-demo/src/app/app.component.html
+++ b/angular/projects/catalyst-demo/src/app/app.component.html
@@ -25,11 +25,26 @@
     [connector]="countryConnector"
     [clearable]="true"
   ></cat-select>
+  <!--  Datepicker Section 1 -->
+  <cat-checkbox #checkBox
+                label="Should disable next datepicker">
+  </cat-checkbox>
+  <cat-datepicker
+    [disabled]="checkBox.checked"
+    label="Datepicker"
+    [nativeAttributes]="{ 'data-test': 'test-attribute' }"
+    hint="Depends on [disabled] attribute"
+  ></cat-datepicker>
+  <!--  Datepicker Section 2 -->
+  <cat-checkbox (catChange)="onCheckboxChange($event)"
+                formControlName="datepickerDisabled"
+                label="Should disable next datepicker">
+  </cat-checkbox>
   <cat-datepicker
     label="Datepicker"
     formControlName="date"
     [nativeAttributes]="{ 'data-test': 'test-attribute' }"
-    hint="this is a hint"
+    hint="Depends on formControl state"
   ></cat-datepicker>
   <formly-form [form]="form" [fields]="fields"></formly-form>
 </form>

--- a/angular/projects/catalyst-demo/src/app/app.component.ts
+++ b/angular/projects/catalyst-demo/src/app/app.component.ts
@@ -28,7 +28,8 @@ export class AppComponent implements OnInit {
     test: new FormControl('test', [Validators.pattern('a+'), Validators.required, Validators.minLength(3)]),
     relatedInput: new FormControl(null, [this.equalTo('test')]),
     option: new FormControl(null, [Validators.required]),
-    date: new FormControl(null, [Validators.required])
+    date: new FormControl(null, [Validators.required]),
+    datepickerDisabled: new FormControl(true)
   });
 
   countryConnector = countryConnector;
@@ -148,6 +149,20 @@ export class AppComponent implements OnInit {
     this.form.controls.test.valueChanges.subscribe(() => {
       this.form.controls.relatedInput.updateValueAndValidity();
     });
+    if (this.form.controls.datepickerDisabled.value) {
+      this.form.controls.date.disable();
+    } else {
+      this.form.controls.date.enable();
+    }
+  }
+
+  onCheckboxChange(event: Event) {
+    const checkbox = event.target as HTMLInputElement;
+    if (checkbox.checked) {
+      this.form.controls.date.disable();
+    } else {
+      this.form.controls.date.enable();
+    }
   }
 
   equalTo(controlName: string) {

--- a/core/src/components/cat-datepicker/cat-datepicker.tsx
+++ b/core/src/components/cat-datepicker/cat-datepicker.tsx
@@ -200,7 +200,7 @@ export class CatDatepickerFlat {
     this.pickr?.destroy();
     this.pickr = undefined;
     setTimeout(() => {
-      this.input ? this.input.disabled = this.disabled : null
+      this.input ? (this.input.disabled = this.disabled) : null;
       this.pickr = this.initDatepicker(this.input);
     });
   }

--- a/core/src/components/cat-datepicker/cat-datepicker.tsx
+++ b/core/src/components/cat-datepicker/cat-datepicker.tsx
@@ -192,14 +192,19 @@ export class CatDatepickerFlat {
   }
 
   @Watch('disabled')
+  onDisabledChanged(value: boolean) {
+    this.pickr?.set('clickOpens', !value && !this.readonly);
+    if (this.pickr?.altInput) {
+      this.pickr.altInput.disabled = value;
+    }
+  }
+
   @Watch('readonly')
-  onDisabledChanged() {
-    // Dynamically changing 'disabled' value is not working due to a bug in the
-    // library. We thus need to fully recreate the date picker after the value
-    // has been updated.
-    this.pickr?.destroy();
-    this.pickr = undefined;
-    setTimeout(() => (this.pickr = this.initDatepicker(this.input)));
+  onReadonlyChanged(value: boolean) {
+    this.pickr?.set('clickOpens', !value && !this.disabled);
+    if (this.pickr?.altInput) {
+      this.pickr.altInput.readOnly = value;
+    }
   }
 
   componentDidLoad() {
@@ -297,7 +302,7 @@ export class CatDatepickerFlat {
   }
 
   private initDatepicker(input?: HTMLInputElement): flatpickr.Instance | undefined {
-    if (this.disabled || this.readonly || !input) {
+    if (!input) {
       return;
     }
 

--- a/core/src/components/cat-datepicker/cat-datepicker.tsx
+++ b/core/src/components/cat-datepicker/cat-datepicker.tsx
@@ -192,19 +192,17 @@ export class CatDatepickerFlat {
   }
 
   @Watch('disabled')
-  onDisabledChanged(value: boolean) {
-    this.pickr?.set('clickOpens', !value && !this.readonly);
-    if (this.pickr?.altInput) {
-      this.pickr.altInput.disabled = value;
-    }
-  }
-
   @Watch('readonly')
-  onReadonlyChanged(value: boolean) {
-    this.pickr?.set('clickOpens', !value && !this.disabled);
-    if (this.pickr?.altInput) {
-      this.pickr.altInput.readOnly = value;
-    }
+  onDisabledChanged() {
+    // Dynamically changing 'disabled' value is not working due to a bug in the
+    // library. We thus need to fully recreate the date picker after the value
+    // has been updated.
+    this.pickr?.destroy();
+    this.pickr = undefined;
+    setTimeout(() => {
+      this.input ? this.input.disabled = this.disabled : null
+      this.pickr = this.initDatepicker(this.input);
+    });
   }
 
   componentDidLoad() {


### PR DESCRIPTION
**What:**
Bug fix for the datepicker.

**Steps to reproduce old behavior:**
1. Create a checkbox and a datepicker
2. Set [disabled] attribute to depend on a checkbox. Can be like a reference on a checkbox: #checkbox.checked.
3. Checkbox is set as true
4. Try to click twice on a checkbox fast (might require some attempts)
_Expected result:_ 
datepicker is working (clickable, date can be picked)
_Actual result:_
datepicker is broken. Calendar is not shown, date can't be picked.

Additional info:
Any other approach of using API didn't work as expected. I tried to combine 'disable', 'allowInput' from https://flatpickr.js.org/options/ but nothing worked well. So I accessed altInput which I used to implement the logic.

![datepicker-26](https://github.com/haiilo/catalyst/assets/10977856/4ffeb39f-bf52-4825-9ac7-00c1e5134127)
(on the gif you can see like after clicking twice on a checkbox datepicker stopped opening)