### PR TITLE
fix(core): make mode dynamically changeable for datepicker

### DIFF
--- a/angular/projects/catalyst-demo/src/app/app.component.html
+++ b/angular/projects/catalyst-demo/src/app/app.component.html
@@ -27,10 +27,10 @@
   ></cat-select>
   <!--  Datepicker Section 1 -->
   <cat-checkbox #checkBox
-                label="Should disable next datepicker">
+                label="Should toggle between date and datetime">
   </cat-checkbox>
   <cat-datepicker
-    [disabled]="checkBox.checked"
+    [mode]="checkBox.checked ? 'date' : 'datetime'"
     label="Datepicker"
     [nativeAttributes]="{ 'data-test': 'test-attribute' }"
     hint="Depends on [disabled] attribute"

--- a/core/src/components/cat-datepicker/cat-datepicker.tsx
+++ b/core/src/components/cat-datepicker/cat-datepicker.tsx
@@ -193,8 +193,9 @@ export class CatDatepickerFlat {
 
   @Watch('disabled')
   @Watch('readonly')
+  @Watch('mode')
   onDisabledChanged() {
-    // Dynamically changing 'disabled' value is not working due to a bug in the
+    // Dynamically changing config value is not working due to a bug in the
     // library. We thus need to fully recreate the date picker after the value
     // has been updated.
     this.pickr?.destroy();
@@ -204,6 +205,7 @@ export class CatDatepickerFlat {
       this.pickr = this.initDatepicker(this.input);
     });
   }
+
 
   componentDidLoad() {
     this.pickr = this.initDatepicker(this.input);

--- a/core/src/components/cat-datepicker/cat-datepicker.tsx
+++ b/core/src/components/cat-datepicker/cat-datepicker.tsx
@@ -206,7 +206,6 @@ export class CatDatepickerFlat {
     });
   }
 
-
   componentDidLoad() {
     this.pickr = this.initDatepicker(this.input);
   }


### PR DESCRIPTION
In order to be able to switch the type of the datepicker dynamically we need to reinstanciate the datepicker like we did for readonly and disabled already.