### PR TITLE
feat(core): add reverse flex direction classes

### DIFF
--- a/core/src/styles/utils/_layout.scss
+++ b/core/src/styles/utils/_layout.scss
@@ -12,7 +12,13 @@
 @include -layout-property('flex-row', 'flex-direction', 'row') {
   display: flex;
 }
+@include -layout-property('flex-row-rev', 'flex-direction', 'row-reverse') {
+  display: flex;
+}
 @include -layout-property('flex-col', 'flex-direction', 'column') {
+  display: flex;
+}
+@include -layout-property('flex-col-rev', 'flex-direction', 'column-reverse') {
   display: flex;
 }
 


### PR DESCRIPTION
**What has been done:**
* Added utility layout classes for flex-direction reverse options (col and row)

**What to test:**
* It works

**Additional Info**
* @fynnfeldpausch I wanted to adjust the documentation [here](https://design.haiilo.com/7a807c8eb/p/069dc7-layout/t/page-069dc7-48935622-2), but I didn't find where to. Can you point me out to it? Thank you.
* It's the first PR I make for Catalyst (I think). So I'm not completely sure of the rules and guidelines. Let me know if there's something more i need to take care of.