### PR TITLE
feat(core): use minWidth: true setting for cat-select input autosize

### DIFF
--- a/core/src/components/cat-select/cat-select.tsx
+++ b/core/src/components/cat-select/cat-select.tsx
@@ -352,7 +352,7 @@ export class CatSelect {
 
   componentDidLoad(): void {
     if (this.input) {
-      autosizeInput(this.input);
+      autosizeInput(this.input, { minWidth: true });
     }
     if (this.trigger && this.dropdown) {
       autoUpdate(this.trigger, this.dropdown, () => this.update());


### PR DESCRIPTION

![Screenshot 2024-08-21 at 13 38 27](https://github.com/user-attachments/assets/2d7d2ac0-df4a-4809-a30f-de38cdacbea2)
The search input size can be calculated as very small w/o minWidth:true config and I input has placeholder it would be cut off