### PR TITLE
feat(core): fix submit mode for cat-button

### DIFF
--- a/core/src/components/cat-button/cat-button.tsx
+++ b/core/src/components/cat-button/cat-button.tsx
@@ -1,6 +1,7 @@
 import { Component, Element, Event, EventEmitter, h, Listen, Method, Prop, State, Watch } from '@stencil/core';
 import { Breakpoint, Breakpoints, isBreakpoint } from '../../utils/breakpoints';
 import { MediaMatcher } from '../../utils/media-matcher';
+import { findClosest } from '../../utils/find-closest';
 
 /**
  * Buttons are used for interface actions. Primary style should be used only
@@ -196,6 +197,9 @@ export class CatButton {
     if (this.disabled || this.loading) {
       event.preventDefault();
       event.stopImmediatePropagation();
+    } else if (this.submit) {
+      const form = findClosest('form', this.hostElement);
+      form?.dispatchEvent(new SubmitEvent('submit', { submitter: this.button }));
     }
   }
 


### PR DESCRIPTION
Currently shadowDom doesn't let any events to pass(including submit) above to the parent dom tree, so we need to dispatch submit event manually to the nearest form