### PR TITLE
fix(core): fix setting value programmatically on cat-time

### DIFF
--- a/angular/projects/catalyst-demo/src/app/app.component.html
+++ b/angular/projects/catalyst-demo/src/app/app.component.html
@@ -3,9 +3,17 @@
 <button (click)="openDialog()">Open</button>
 <h2>Form Components</h2>
 <form [formGroup]="form">
-  <h1>new datepicker & timepicker</h1>
-  <cat-date label="Date" formControlName="date2" clearable></cat-date>
-  <cat-time label="Time" formControlName="time" clearable></cat-time>
+  <h1>new datetime picker</h1>
+  <cat-toggle formControlName="toggle">
+    <div slot="label">
+      <div>LABEL START</div>
+      <div>Subline</div>
+    </div>
+  </cat-toggle>
+  <cat-datetime label="Datetime" formControlName="dateTime" clearable>
+    <cat-date label="Date start"></cat-date>
+    <cat-time label="Time start"></cat-time>
+  </cat-datetime>
   <pre>{{ form.getRawValue() | json }}</pre>
   <cat-input
     label="Input"

--- a/angular/projects/catalyst-demo/src/app/app.component.ts
+++ b/angular/projects/catalyst-demo/src/app/app.component.ts
@@ -31,7 +31,7 @@ export class AppComponent implements OnInit {
     date: new FormControl(null, [Validators.required]),
     date2: new FormControl(null, [Validators.required]),
     time: new FormControl('20:20', [Validators.required]),
-    dateTime: new FormControl(new Date('Thu Jun 01 2000 00:59:00 GMT+0100'), [Validators.required]),
+    dateTime: new FormControl(new Date('Thu Jun 01 2000 01:00:00 GMT+0100'), [Validators.required]),
     toggle: new FormControl(true),
     datepickerDisabled: new FormControl(true)
   });
@@ -151,7 +151,7 @@ export class AppComponent implements OnInit {
 
   ngOnInit(): void {
     this.form.controls.test.valueChanges.subscribe(() => {
-      this.form.controls.dateTime.setValue(new Date())
+      this.form.controls.dateTime.setValue(new Date('Thu Jun 01 2000 15:00:00 GMT+0100'));
       this.form.controls.relatedInput.updateValueAndValidity();
     });
     if (this.form.controls.datepickerDisabled.value) {

--- a/angular/projects/catalyst-demo/src/app/app.component.ts
+++ b/angular/projects/catalyst-demo/src/app/app.component.ts
@@ -31,6 +31,8 @@ export class AppComponent implements OnInit {
     date: new FormControl(null, [Validators.required]),
     date2: new FormControl(null, [Validators.required]),
     time: new FormControl('20:20', [Validators.required]),
+    dateTime: new FormControl(new Date('Thu Jun 01 2000 00:59:00 GMT+0100'), [Validators.required]),
+    toggle: new FormControl(true),
     datepickerDisabled: new FormControl(true)
   });
 
@@ -149,6 +151,7 @@ export class AppComponent implements OnInit {
 
   ngOnInit(): void {
     this.form.controls.test.valueChanges.subscribe(() => {
+      this.form.controls.dateTime.setValue(new Date())
       this.form.controls.relatedInput.updateValueAndValidity();
     });
     if (this.form.controls.datepickerDisabled.value) {

--- a/core/src/components/cat-time/cat-time.tsx
+++ b/core/src/components/cat-time/cat-time.tsx
@@ -28,7 +28,7 @@ export class CatTime {
 
   @State() isAm = true;
 
-  @State() programmaticallyChanged = false;
+  @State() valueChangedBySelection = false;
 
   /**
    * Whether the label need a marker to shown if the input is required or optional.
@@ -178,12 +178,9 @@ export class CatTime {
 
   @Watch('value')
   onValueChanged(value: string, oldValue: string) {
-    if (this.programmaticallyChanged) {
-      this.programmaticallyChanged = false;
-      return;
-    }
-    if (value !== oldValue) {
-      this.programmaticallyChanged = true;
+    if (this.valueChangedBySelection) {
+      this.valueChangedBySelection = false;
+    } else if (value !== oldValue) {
       this.set12hFormat();
       this.syncValue(value);
     }
@@ -259,11 +256,11 @@ export class CatTime {
       this.input.value = this.format(this.selectionTime, false);
     }
     if (oldValue !== newValue) {
-      this.programmaticallyChanged = true;
+      this.valueChangedBySelection = true;
       this.value = newValue;
       this.catChange.emit(this.value);
     } else {
-      this.programmaticallyChanged = false;
+      this.valueChangedBySelection = false;
     }
   }
 

--- a/core/src/index.html
+++ b/core/src/index.html
@@ -856,11 +856,11 @@
               </cat-form-group>
 
               <script>
-                let input = document.getElementById("cat-input-1");
+                let input = document.getElementById('cat-input-1');
                 input.addEventListener('input', () => {
                   let elementById = document.getElementById('time2');
-                  elementById.value = "13:58";
-                })
+                  elementById.value = '13:58';
+                });
                 const formElem = document.getElementById('form-group-1');
                 setTimeout(() => {
                   const htmlElement = document.createElement('cat-input');
@@ -915,7 +915,7 @@
             <section id="datepicker" class="cat-form">
               <h2>Datepicker</h2>
               <cat-date label="New Datepicker"></cat-date>
-              <cat-time id="time2" label="New Timepicker"></cat-time>
+              <cat-time id="time2" label="New Timepicker" value="12:00"></cat-time>
               <cat-datepicker mode="date">
                 <span slot="label">Priority Label</span>
                 <span slot="hint">Priority Hint</span>
@@ -970,7 +970,6 @@
                     action: 'Seite neu laden'
                   });
                 };
-                document.querySelector()
               </script>
             </section>
 

--- a/core/src/index.html
+++ b/core/src/index.html
@@ -851,11 +851,16 @@
 
               <h3>Dynamic field added</h3>
               <cat-form-group id="form-group-1">
-                <cat-input label="Field 1"></cat-input>
+                <cat-input id="cat-input-1" label="Field 1"></cat-input>
                 <cat-input label="Field 2" required></cat-input>
               </cat-form-group>
 
               <script>
+                let input = document.getElementById("cat-input-1");
+                input.addEventListener('input', () => {
+                  let elementById = document.getElementById('time2');
+                  elementById.value = "13:58";
+                })
                 const formElem = document.getElementById('form-group-1');
                 setTimeout(() => {
                   const htmlElement = document.createElement('cat-input');
@@ -910,7 +915,7 @@
             <section id="datepicker" class="cat-form">
               <h2>Datepicker</h2>
               <cat-date label="New Datepicker"></cat-date>
-              <cat-time label="New Timepicker"></cat-time>
+              <cat-time id="time2" label="New Timepicker"></cat-time>
               <cat-datepicker mode="date">
                 <span slot="label">Priority Label</span>
                 <span slot="hint">Priority Hint</span>
@@ -965,6 +970,7 @@
                     action: 'Seite neu laden'
                   });
                 };
+                document.querySelector()
               </script>
             </section>
 


### PR DESCRIPTION
Fix an issue where the input value was not changed or been set properly when setting a value programmatically on the cat-time.
This also fix some issues on the 12 hours format where the AM/PM were not being set properly on load. When for example the time was set to PM and we were changing it programmatically to AM time, the AM/PM button was not changed.