### PR TITLE
fix(core): setting empty value in cat-time

### DIFF
--- a/core/src/components/cat-time/cat-time.tsx
+++ b/core/src/components/cat-time/cat-time.tsx
@@ -182,7 +182,7 @@ export class CatTime {
       this.valueChangedBySelection = false;
     } else if (value !== oldValue) {
       this.set12hFormat();
-      this.syncValue(value);
+      this.syncValue(value ?? '');
     }
   }
 

--- a/core/src/components/cat-time/cat-time.tsx
+++ b/core/src/components/cat-time/cat-time.tsx
@@ -243,7 +243,7 @@ export class CatTime {
     let newValue = this.value;
     if (!date) {
       this.selectionTime = null;
-      this.value = undefined;
+      newValue = undefined;
     } else {
       const time = clampTime(this.min ?? null, date, this.max ?? null);
       this.isAm = this.format(time).toLowerCase().includes('am');


### PR DESCRIPTION
**What has been done:**
* set empty value for cat-time onValueChange aka Watch

**What to test:**
* Errors are not thrown when deleting or clearing the cat-time input 