### PR TITLE
fix(angular): fix position of popup cat-elements inside cat-dialog

### DIFF
--- a/angular/projects/catalyst-demo/src/app/dialog/dialog.component.html
+++ b/angular/projects/catalyst-demo/src/app/dialog/dialog.component.html
@@ -11,12 +11,20 @@
     [attachToElement]="true"
   >
   </cat-datepicker>
-  <p>
-    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore
-    magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd
-    gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing
-    elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
-  </p>
+  <cat-dropdown>
+    <cat-button slot="trigger">Click me</cat-button>
+    <p slot="content">
+      Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+      dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita
+      kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur
+      sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+      voluptua.
+    </p>
+  </cat-dropdown>
+  <cat-datetime label="Datetime" clearable>
+    <cat-date label="Date start"></cat-date>
+    <cat-time label="Time start"></cat-time>
+  </cat-datetime>
 
   <form [formGroup]="form">
     <cat-select
@@ -32,6 +40,8 @@
   <cat-dialog-actions>
     <cat-button variant="text" class="cat-mr-auto">Tertiary</cat-button>
     <cat-button>Secondary</cat-button>
-    <cat-button variant="filled" color="primary">Primary</cat-button>
+    <cat-tooltip content="Primary">
+      <cat-button variant="filled" color="primary">Primary</cat-button>
+    </cat-tooltip>
   </cat-dialog-actions>
 </cat-dialog>

--- a/angular/projects/catalyst/src/lib/dialog/dialog.component.scss
+++ b/angular/projects/catalyst/src/lib/dialog/dialog.component.scss
@@ -9,6 +9,8 @@
 }
 
 .cat-dialog-pane {
+  transform: translateZ(0);
+
   .cdk-dialog-container > *:only-child {
     display: block;
     width: 100%;


### PR DESCRIPTION
A workaround for https://github.com/haiilo/catalyst/issues/569

**What is happening?**
The floating elements of catalyst have the position property as `fixed`. When the elements are inside the dialog the position is calculated with the new container element, but it seems that the new chrome version (129) still sets the viewport as the container. That is to say, the position calculations are ok but when rendering it, the container element is the viewport instead of the dialog.

**What has been done?**
Dialog has been chosen as the new container element. 
https://developer.mozilla.org/en-US/docs/Web/CSS/position#fixed_positioning

**What to test?**
- With the Angular project running, check that the floating elements (`cat-dropdown`, `cat-date`, `cat-time`, `cat-tooltip`, `cat-select`, `cat-date`, `cat-datepicker` although it is deprecated) are positioned well within the dialog. 
- Test it with the latest version of chrome and in other browsers.