### PR TITLE
fix(core): cat-date-inline month display in headline

### DIFF
--- a/core/src/components/cat-date-inline/cat-date-inline.tsx
+++ b/core/src/components/cat-date-inline/cat-date-inline.tsx
@@ -430,7 +430,7 @@ export class CatDateInline {
   }
 
   private getHeadline() {
-    return `${this.locale.months.long[this.viewDate.getMonth()]} ${this.viewDate.getFullYear()}`;
+    return `${this.viewDate.toLocaleString('default', { month: 'long' })} ${this.viewDate.getFullYear()}`;
   }
 
   private getWeekNumber(date: Date, iso8601 = true) {

--- a/core/src/components/cat-date-inline/cat-date-inline.tsx
+++ b/core/src/components/cat-date-inline/cat-date-inline.tsx
@@ -430,7 +430,7 @@ export class CatDateInline {
   }
 
   private getHeadline() {
-    return `${this.viewDate.toLocaleString('default', { month: 'long' })} ${this.viewDate.getFullYear()}`;
+    return `${this.viewDate.toLocaleString(this.language, { month: 'long' })} ${this.viewDate.getFullYear()}`;
   }
 
   private getWeekNumber(date: Date, iso8601 = true) {

--- a/core/src/components/cat-date-inline/cat-date-inline.tsx
+++ b/core/src/components/cat-date-inline/cat-date-inline.tsx
@@ -430,7 +430,7 @@ export class CatDateInline {
   }
 
   private getHeadline() {
-    return `${this.viewDate.toLocaleString(this.language, { month: 'long' })} ${this.viewDate.getFullYear()}`;
+    return `${this.locale.months.long[this.viewDate.getMonth()]} ${this.viewDate.getFullYear()}`;
   }
 
   private getWeekNumber(date: Date, iso8601 = true) {

--- a/core/src/components/cat-date-inline/cat-date-locale.ts
+++ b/core/src/components/cat-date-inline/cat-date-locale.ts
@@ -13,7 +13,8 @@ function getMonths(language: string, month: 'long' | 'short' = 'long') {
 
   return Array.from({ length: 12 }, (_, index) => {
     const fixedDate = new Date(date.getTime());
-    fixedDate.setMonth(index);
+    fixedDate.setUTCMonth(index);
+    fixedDate.setUTCHours(12);
 
     return format(fixedDate);
   });

--- a/core/src/components/cat-date-inline/cat-date-locale.ts
+++ b/core/src/components/cat-date-inline/cat-date-locale.ts
@@ -8,16 +8,8 @@ function getDays(language: string, weekday: 'long' | 'short' | 'narrow' = 'long'
 }
 
 function getMonths(language: string, month: 'long' | 'short' = 'long') {
-  const date = new Date(0);
   const format = new Intl.DateTimeFormat(language, { month }).format;
-
-  return Array.from({ length: 12 }, (_, index) => {
-    const fixedDate = new Date(date.getTime());
-    fixedDate.setUTCMonth(index);
-    fixedDate.setUTCHours(12);
-
-    return format(fixedDate);
-  });
+  return [...Array(12).keys()].map(month => format(new Date(2000, month, 1)));
 }
 
 function getWeekInfo(language: string) {

--- a/core/src/components/cat-date-inline/cat-date-locale.ts
+++ b/core/src/components/cat-date-inline/cat-date-locale.ts
@@ -10,7 +10,14 @@ function getDays(language: string, weekday: 'long' | 'short' | 'narrow' = 'long'
 function getMonths(language: string, month: 'long' | 'short' = 'long') {
   const date = new Date(0);
   const format = new Intl.DateTimeFormat(language, { month }).format;
-  return [...Array(12).keys()].map(month => format(new Date(date.getTime()).setUTCMonth(month)));
+
+  return Array.from({ length: 12 }, (_, index) => {
+    const fixedDate = new Date(date.getTime());
+    fixedDate.setUTCMonth(index);
+    fixedDate.setUTCHours(12);
+
+    return format(fixedDate);
+  });
 }
 
 function getWeekInfo(language: string) {

--- a/core/src/components/cat-date-inline/cat-date-locale.ts
+++ b/core/src/components/cat-date-inline/cat-date-locale.ts
@@ -13,8 +13,7 @@ function getMonths(language: string, month: 'long' | 'short' = 'long') {
 
   return Array.from({ length: 12 }, (_, index) => {
     const fixedDate = new Date(date.getTime());
-    fixedDate.setUTCMonth(index);
-    fixedDate.setUTCHours(12);
+    fixedDate.setMonth(index);
 
     return format(fixedDate);
   });


### PR DESCRIPTION
This pull request fixe  the cat date inline month headline because when we switch from locale, as an example switching from DE to US, the index in the array of `locale.months.long` also changed impacting only the US customers, that will see the title showing the previous month:


![Screenshot 2025-01-17 at 15 14 19](https://github.com/user-attachments/assets/e9c7790a-3bbc-4ed2-af1c-ca748f18bf83)
![Screenshot 2025-01-17 at 10 39 12](https://github.com/user-attachments/assets/b577f0ad-69db-4ff5-b6b8-7b8ed7304fad)
