### PR TITLE
fix(core): fix multi-select in Safari

### DIFF
--- a/core/src/components/cat-checkbox/cat-checkbox.spec.tsx
+++ b/core/src/components/cat-checkbox/cat-checkbox.spec.tsx
@@ -8,7 +8,7 @@ describe('cat-checkbox', () => {
       html: `<cat-checkbox label="Label"></cat-checkbox>`
     });
     expect(page.root).toEqualLightHtml(`
-     <cat-checkbox label="Label" tabindex="0"></cat-checkbox>
+     <cat-checkbox label="Label"></cat-checkbox>
     `);
   });
 });

--- a/core/src/components/cat-checkbox/cat-checkbox.tsx
+++ b/core/src/components/cat-checkbox/cat-checkbox.tsx
@@ -16,9 +16,7 @@ let nextUniqueId = 0;
 @Component({
   tag: 'cat-checkbox',
   styleUrls: ['cat-checkbox.scss'],
-  shadow: {
-    delegatesFocus: true
-  }
+  shadow: true
 })
 export class CatCheckbox {
   private readonly _id = `cat-checkbox-${nextUniqueId++}`;
@@ -164,7 +162,6 @@ export class CatCheckbox {
   }
 
   render() {
-    this.hostElement.tabIndex = Number(this.hostElement.getAttribute('tabindex')) || 0;
     return (
       <Host>
         <label


### PR DESCRIPTION
fixes #655 

There is an issue in Safari for shadow dom components related to focus and blur. When we focus on button, input with type checkbox and some other components (I don't have a full list) the shadow component itself receives blur event.

And in cat-select we are listening blur event and close dropdown when blur triggers.

Unfortunately there is no way to NOT emit blur event in Safari except NOT using delegateFocus parameter in Stencil for child shadow component. I haven't checked yet the Stencil implementation, but seems like they figured out some workaround because if you just check how native shadow components then absence of delegatefocus doesn't change anything.

So far possible solutions which I have in mind:

use polyfill for Safari and add few conditions in Blur event handler in cat-select
listen for click and keyboard events instead of Blur event
This is a quick fix to make multi selects work again in Safati and I will create a follow up ticket to make select work even if all children have delegatefocus property.