### PR TITLE
fix(core): do not show focus in dropdown if it was opened by mouse click

### DIFF
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -691,6 +691,7 @@ export namespace Components {
         "noAutoClose": boolean;
         /**
           * No element in dropdown will receive focus when dropdown is open. By default, the first element in tab order will receive a focus.
+          * @deprecated
          */
         "noInitialFocus": boolean;
         /**
@@ -703,8 +704,9 @@ export namespace Components {
         "noReturnFocus": boolean;
         /**
           * Opens the dropdown.
+          * @param isFocusVisible is dropdown should receive visible focus when it's opened.
          */
-        "open": () => Promise<void>;
+        "open": (isFocusVisible?: boolean) => Promise<void>;
         /**
           * Allow overflow when dropdown is open.
          */
@@ -2992,6 +2994,7 @@ declare namespace LocalJSX {
         "noAutoClose"?: boolean;
         /**
           * No element in dropdown will receive focus when dropdown is open. By default, the first element in tab order will receive a focus.
+          * @deprecated
          */
         "noInitialFocus"?: boolean;
         /**

--- a/core/src/components/cat-dropdown/readme.md
+++ b/core/src/components/cat-dropdown/readme.md
@@ -12,15 +12,15 @@ show additional content on demand.
 
 ## Properties
 
-| Property          | Attribute          | Description                                                                                                                            | Type                                                                                                                                                                 | Default          |
-| ----------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| `arrowNavigation` | `arrow-navigation` | Do not navigate focus inside the dropdown via vertical arrow keys.                                                                     | `"horizontal" \| "none" \| "vertical"`                                                                                                                               | `'vertical'`     |
-| `noAutoClose`     | `no-auto-close`    | Do not close the dropdown on outside clicks.                                                                                           | `boolean`                                                                                                                                                            | `false`          |
-| `noInitialFocus`  | `no-initial-focus` | No element in dropdown will receive focus when dropdown is open. By default, the first element in tab order will receive a focus.      | `boolean`                                                                                                                                                            | `false`          |
-| `noResize`        | `no-resize`        | Do not change the size of the dropdown to ensure it isn’t too big to fit in the viewport (or more specifically, its clipping context). | `boolean`                                                                                                                                                            | `false`          |
-| `noReturnFocus`   | `no-return-focus`  | Trigger element will not receive focus when dropdown is closed.                                                                        | `boolean`                                                                                                                                                            | `false`          |
-| `overflow`        | `overflow`         | Allow overflow when dropdown is open.                                                                                                  | `boolean`                                                                                                                                                            | `false`          |
-| `placement`       | `placement`        | The placement of the dropdown.                                                                                                         | `"bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"` | `'bottom-start'` |
+| Property          | Attribute          | Description                                                                                                                                                                                 | Type                                                                                                                                                                 | Default          |
+| ----------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `arrowNavigation` | `arrow-navigation` | Do not navigate focus inside the dropdown via vertical arrow keys.                                                                                                                          | `"horizontal" \| "none" \| "vertical"`                                                                                                                               | `'vertical'`     |
+| `noAutoClose`     | `no-auto-close`    | Do not close the dropdown on outside clicks.                                                                                                                                                | `boolean`                                                                                                                                                            | `false`          |
+| `noInitialFocus`  | `no-initial-focus` | <span style="color:red">**[DEPRECATED]**</span> <br/><br/>No element in dropdown will receive focus when dropdown is open. By default, the first element in tab order will receive a focus. | `boolean`                                                                                                                                                            | `false`          |
+| `noResize`        | `no-resize`        | Do not change the size of the dropdown to ensure it isn’t too big to fit in the viewport (or more specifically, its clipping context).                                                      | `boolean`                                                                                                                                                            | `false`          |
+| `noReturnFocus`   | `no-return-focus`  | Trigger element will not receive focus when dropdown is closed.                                                                                                                             | `boolean`                                                                                                                                                            | `false`          |
+| `overflow`        | `overflow`         | Allow overflow when dropdown is open.                                                                                                                                                       | `boolean`                                                                                                                                                            | `false`          |
+| `placement`       | `placement`        | The placement of the dropdown.                                                                                                                                                              | `"bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"` | `'bottom-start'` |
 
 
 ## Events
@@ -43,9 +43,15 @@ Type: `Promise<void>`
 
 
 
-### `open() => Promise<void>`
+### `open(isFocusVisible?: boolean) => Promise<void>`
 
 Opens the dropdown.
+
+#### Parameters
+
+| Name             | Type                   | Description                                                |
+| ---------------- | ---------------------- | ---------------------------------------------------------- |
+| `isFocusVisible` | `boolean \| undefined` | is dropdown should receive visible focus when it's opened. |
 
 #### Returns
 


### PR DESCRIPTION
**Context**
When user uses dropdown, the first element in dropdown gets focus regardless of origin. It might be opened by mouse click, by keyboard or by api and focus will be received all the time. We only had `hasInitialFocus` property to regulate this, but mainly users are interested to see focus when it's opened by keyboard and do not receive focus when it's opened by mouse.

**What has been done**

Track if click event was received from keyboard + `open` method accepts a parameter `isFocusVisible` to override internal state and pass this to `initialFocus` api function of focus-track.