### PR TITLE
feat(core): use shift middleware for dropdown compute position method

### DIFF
--- a/core/src/components/cat-dropdown/cat-dropdown.tsx
+++ b/core/src/components/cat-dropdown/cat-dropdown.tsx
@@ -1,4 +1,4 @@
-import { autoUpdate, computePosition, flip, offset, Placement, ReferenceElement, size } from '@floating-ui/dom';
+import { autoUpdate, computePosition, flip, offset, Placement, ReferenceElement, shift, size } from '@floating-ui/dom';
 import { timeTransitionS } from '@haiilo/catalyst-tokens';
 import { Component, Event, EventEmitter, h, Host, Listen, Method, Prop } from '@stencil/core';
 import * as focusTrap from 'focus-trap';
@@ -295,7 +295,7 @@ export class CatDropdown {
       computePosition(anchorElement, this.content, {
         strategy: 'fixed',
         placement: this.placement,
-        middleware: [offset(CatDropdown.OFFSET), flip(), ...resize]
+        middleware: [offset(CatDropdown.OFFSET), flip(), shift(), ...resize]
       }).then(({ x, y, placement }) => {
         this.content.dataset.placement = placement;
         Object.assign(this.content.style, {


### PR DESCRIPTION
fixes #652 

before introducing shift() middleware
![Screenshot 2025-03-26 at 13 06 30](https://github.com/user-attachments/assets/7069087d-2eb1-4776-bd14-1842b5908324)

with shift()
![Screenshot 2025-03-26 at 13 05 43](https://github.com/user-attachments/assets/5d5901a7-4fba-4c83-bf83-c192ece6284d)
 