### PR TITLE
feat(angular): fix time value update in datetime component

### DIFF
--- a/angular/projects/catalyst/src/lib/datetime/datetime.component.ts
+++ b/angular/projects/catalyst/src/lib/datetime/datetime.component.ts
@@ -63,7 +63,14 @@ export class DatetimeComponent implements AfterContentInit, ControlValueAccessor
     this.lastValue = this.lastDateValue = this.lastTimeValue = value;
     setTimeout(() => {
       this.dateInput?.writeValue(value);
+      const timeAfterChangeDate = this.value?.getTime();
+      this.limitTime('min');
+      this.limitTime('max');
+      const isTimeChangedAfterLimit = this.value?.getTime() !== timeAfterChangeDate;
       this.timeInput?.writeValue(value);
+      if (isTimeChangedAfterLimit) {
+        this.timeInput?.handleChangeEvent(this.timeInput?.nativeElement.value);
+      }
     });
   }
 


### PR DESCRIPTION
Problem 1 
If new datetime value has different day in comparison with previous value then the new min/max limit will be updated only after the time value is specified 
Solution: update min and max limit before write time value

Problem 2 (following after solution 1)
If limiting time changes the time then it will be handled and triggered on top to the form and values between form and dateTime form control will not be synced
Solution: check if time was changed after limit update and trigger onChange

Reference functionality: setting start and end time of event. End time calculation logic adds 1 hour to the start time. When we choose 11pm as a start time then end time calculation wouldn't be correct