### PR TITLE
feat(core): allow typing decimal numbers in input type number

### DIFF
--- a/core/src/components/cat-input/cat-input.e2e.ts
+++ b/core/src/components/cat-input/cat-input.e2e.ts
@@ -10,4 +10,19 @@ describe('cat-input', () => {
     const element = await page.find('cat-input');
     expect(element).toHaveClass('hydrated');
   });
+
+  fit('should input type="number" allow typing numeric characters', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<cat-input type="number"></cat-input>');
+    const input = await page.find('cat-input >>> input');
+    // Entering a mix of allowed and disallowed characters
+    const testSequence = ['1', 'a', '2', '.', '1', '@', '#'];
+    for (const key of testSequence) {
+      await input.press(key);
+    }
+
+    const value = await input.getProperty('value');
+
+    expect(value).toBe('12.1');
+  });
 });

--- a/core/src/components/cat-input/cat-input.e2e.ts
+++ b/core/src/components/cat-input/cat-input.e2e.ts
@@ -11,7 +11,7 @@ describe('cat-input', () => {
     expect(element).toHaveClass('hydrated');
   });
 
-  fit('should input type="number" allow typing numeric characters', async () => {
+  it('should input type="number" allow typing numeric characters', async () => {
     const page = await newE2EPage();
     await page.setContent('<cat-input type="number"></cat-input>');
     const input = await page.find('cat-input >>> input');

--- a/core/src/components/cat-input/cat-input.tsx
+++ b/core/src/components/cat-input/cat-input.tsx
@@ -462,12 +462,13 @@ export class CatInput {
     let formattedValue = this.input.value;
     if (this.timeMaskOptions) {
       formattedValue = formatTime(this.input.value, this.timeMaskOptions);
+      this.input.value = formattedValue;
     }
     if (this.dateMaskOptions) {
       formattedValue = formatDate(this.input.value, this.dateMaskOptions);
+      this.input.value = formattedValue;
     }
     this.value = formattedValue;
-    this.input.value = formattedValue;
     this.internals.setFormValue(this.input.value);
     this.catChange.emit(this.value);
     this.showErrorsIfTimeout();


### PR DESCRIPTION
**Problem:**

It's currently not possible to input decimal numbers because typing characters like the dot (`.`) or comma (`,`) is either blocked or triggers unexpected behavior. These characters are crucial for _decimal_ input.

While trying to type them, the input is cleared, the cursor jumps to the start, or the input simply does not react. This seems to be a regression, and I've submitted this PR with a potential fix.