### PR TITLE
fix(core): remove spacing from box-placeholder width

### DIFF
--- a/core/src/components/cat-checkbox/cat-checkbox.scss
+++ b/core/src/components/cat-checkbox/cat-checkbox.scss
@@ -47,7 +47,7 @@ input {
 }
 
 .box-placeholder {
-  width: calc($checkbox-width);
+  width: $checkbox-width;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
**What has been done:**
* Removed the 2px from the width calculation for the (checkbox) box-placeholder

**What to test:**
* This should make the label and hint slot be aligned

**Context:**
* https://haiilo.atlassian.net/browse/COYOFOUR-24680