### PR TITLE
feat(core)!: closeButton property in cat-notification service options

### DIFF
--- a/core/src/components/cat-notification/cat-notification.tsx
+++ b/core/src/components/cat-notification/cat-notification.tsx
@@ -22,6 +22,8 @@ export interface ToastOptions {
   placement: 'top-left' | 'top-center' | 'top-right' | 'bottom-left' | 'bottom-center' | 'bottom-right';
   /** Enables auto-closing of the notification. (Default: `true`) */
   autoClose: boolean;
+  /** Show button to close the notification. (Default: `false`) */
+  closeButton: boolean;
   /** The duration in ms for the notification to be visible on screen. (Default: `3000`) */
   duration: number;
   /** An optional label for an action button. */
@@ -83,7 +85,7 @@ export class CatNotificationService {
         }
       </div>
       ${
-        options?.autoClose === false
+        options?.closeButton === true
           ? `<cat-button class="cat-toastify-close cat-button-pull" size="s" icon="$cat:notification-close" variant="text" icon-only="true" class="close" a11y-label="${i18n.t(
               'notification.dismiss'
             )}"></cat-button>`

--- a/core/src/index.html
+++ b/core/src/index.html
@@ -1019,11 +1019,12 @@
                 document.getElementById('notification-trigger').onclick = function () {
                   catNotificationService.show('Item saved', {
                     autoClose: false,
+                    closeButton: true,
                     action: 'Show saved items'
                   });
                   catNotificationService.show('This is light', {
                     mode: 'light',
-                    autoClose: false,
+                    closeButton: true,
                     icon: 'globe-outlined',
                     action: 'Seite neu laden'
                   });


### PR DESCRIPTION
fixes #764
If you used `autoClose: false` property in cat-notification service, you need to add closeButton: true explicitly now to make the close button shown