### PR TITLE
fix(angular): change dialog header subline class

### DIFF
--- a/angular/projects/catalyst/src/lib/dialog/dialog-header.component.html
+++ b/angular/projects/catalyst/src/lib/dialog/dialog-header.component.html
@@ -1,6 +1,6 @@
 <div class="cat-dialog-header-content" *ngIf="headline || subline">
   <h3 class="cat-h5 cat-m-0" *ngIf="headline">{{ headline }}</h3>
-  <h4 class="cat-h6 cat-m-0" *ngIf="subline">{{ subline }}</h4>
+  <h4 class="cat-text-m cat-m-0" *ngIf="subline">{{ subline }}</h4>
 </div>
 <ng-content></ng-content>
 <cat-button


### PR DESCRIPTION
**What has been done:**
* Changed cat-dialog-header subline class from cat-h6 to cat-text-m as requested by @mrkskmn 

**What to test:**
* style is correctly applied