### PR TITLE
fix(core): cat-tooltip - add focus and mouse event listeners even for touch screen devices

### DIFF
--- a/core/src/components/cat-tooltip/cat-tooltip.tsx
+++ b/core/src/components/cat-tooltip/cat-tooltip.tsx
@@ -143,28 +143,28 @@ export class CatTooltip {
   }
 
   private addListeners() {
+    this.trigger?.addEventListener('focusin', this.boundShowListener);
+    this.trigger?.addEventListener('focusout', this.boundHideListener);
+    this.trigger?.addEventListener('mouseenter', this.boundShowListener);
+    this.trigger?.addEventListener('mouseleave', this.boundHideListener);
+
     if (isTouchScreen) {
       window.addEventListener('touchstart', this.boundWindowTouchStartListener);
       this.trigger?.addEventListener('touchstart', this.boundTouchStartListener);
       this.trigger?.addEventListener('touchend', this.boundTouchEndListener);
-    } else {
-      this.trigger?.addEventListener('focusin', this.boundShowListener);
-      this.trigger?.addEventListener('focusout', this.boundHideListener);
-      this.trigger?.addEventListener('mouseenter', this.boundShowListener);
-      this.trigger?.addEventListener('mouseleave', this.boundHideListener);
     }
   }
 
   private removeListeners() {
+    this.trigger?.removeEventListener('mouseenter', this.boundShowListener);
+    this.trigger?.removeEventListener('mouseleave', this.boundHideListener);
+    this.trigger?.removeEventListener('focusin', this.boundShowListener);
+    this.trigger?.removeEventListener('focusout', this.boundHideListener);
+
     if (isTouchScreen) {
       window.removeEventListener('touchstart', this.boundWindowTouchStartListener);
       this.trigger?.removeEventListener('touchstart', this.boundTouchStartListener);
       this.trigger?.removeEventListener('touchend', this.boundTouchEndListener);
-    } else {
-      this.trigger?.removeEventListener('mouseenter', this.boundShowListener);
-      this.trigger?.removeEventListener('mouseleave', this.boundHideListener);
-      this.trigger?.removeEventListener('focusin', this.boundShowListener);
-      this.trigger?.removeEventListener('focusout', this.boundHideListener);
     }
   }
 


### PR DESCRIPTION
Some laptops (especially it's popular among Windows devices) have touch screen, which breaks a tooltip behavior, because the current implementation didn't take into account user can use a mouse/keyboard on a touch screen device.

**Fix**: initialize focus and mouse events listeners event when device is detected as touch screen